### PR TITLE
Small clean-ups

### DIFF
--- a/devel/electron4/Makefile
+++ b/devel/electron4/Makefile
@@ -51,7 +51,7 @@ TEST_DEPENDS=	npm:www/npm-node10
 USES=		bison dos2unix gettext-tools gl gnome jpeg localbase:ldflags \
 		ninja pkgconfig python:2.7,build tar:xz
 
-CONFLICTS=	electron5
+CONFLICTS_INSTALL=	electron5
 
 USE_GITHUB=	yes
 GH_TAGNAME=	${DISTVERSIONPREFIX}${ELECTRON_VER}

--- a/devel/electron4/Makefile
+++ b/devel/electron4/Makefile
@@ -51,6 +51,8 @@ TEST_DEPENDS=	npm:www/npm-node10
 USES=		bison dos2unix gettext-tools gl gnome jpeg localbase:ldflags \
 		ninja pkgconfig python:2.7,build tar:xz
 
+CONFLICTS=	electron5
+
 USE_GITHUB=	yes
 GH_TAGNAME=	${DISTVERSIONPREFIX}${ELECTRON_VER}
 # See ${WRKSRC}/electron/DEPS for GH_TAGNAME_node

--- a/devel/electron5/Makefile
+++ b/devel/electron5/Makefile
@@ -3,7 +3,7 @@
 PORTNAME=	electron
 DISTVERSIONPREFIX=	v
 DISTVERSION=	${ELECTRON_VER:S/-beta./.b/}
-CATEGORIES=	devel
+CATEGORIES=	devel java
 MASTER_SITES=	https://github.com/tagattie/FreeBSD-Electron/releases/download/v5.0.1/:chromium \
 		https://commondatastorage.googleapis.com/chromium-nodejs/:chromium_node \
 		https://commondatastorage.googleapis.com/chromium-fonts/:chromium_testfonts

--- a/devel/electron5/Makefile
+++ b/devel/electron5/Makefile
@@ -53,6 +53,7 @@ TEST_DEPENDS=	npm:www/npm
 USES=		bison dos2unix gettext-tools gl gnome jpeg localbase:ldflags \
 		ninja pkgconfig python:2.7,build tar:xz
 
+CONFLICTS=	electron4
 USE_GITHUB=	yes
 GH_TAGNAME=	${DISTVERSIONPREFIX}${ELECTRON_VER}
 # See ${WRKSRC}/electron/DEPS for GH_TAGNAME_node

--- a/devel/electron5/Makefile
+++ b/devel/electron5/Makefile
@@ -53,7 +53,8 @@ TEST_DEPENDS=	npm:www/npm
 USES=		bison dos2unix gettext-tools gl gnome jpeg localbase:ldflags \
 		ninja pkgconfig python:2.7,build tar:xz
 
-CONFLICTS=	electron4
+CONFLICTS_INSTALL=	electron4
+
 USE_GITHUB=	yes
 GH_TAGNAME=	${DISTVERSIONPREFIX}${ELECTRON_VER}
 # See ${WRKSRC}/electron/DEPS for GH_TAGNAME_node


### PR DESCRIPTION
Add mutual CONFLICTS_INSTALL on both ports, because they install files with the same name in the same location.
Add java as secondary category on electron 5, because (I didn't know) electron 5 uses java (chromium and nodejs apparently weren't enough)