### PR TITLE
Fix distdir directory creation and remove the usage of _DISTDIR

### DIFF
--- a/devel/electron4/Makefile
+++ b/devel/electron4/Makefile
@@ -156,7 +156,8 @@ TEST_ALL_TARGET+=	third_party/electron_node:headers
 NPM_TIMESTAMP=	1558165815
 
 pre-fetch:
-	if [ ! -f ${_DISTDIR}/electron-npm-modules-${ELECTRON_VER}${EXTRACT_SUFX} ]; \
+	@${MKDIR} ${DISTDIR}/${DIST_SUBDIR}
+	if [ ! -f ${DISTDIR}/${DIST_SUBDIR}/electron-npm-modules-${ELECTRON_VER}${EXTRACT_SUFX} ]; \
 		then ${MKDIR} ${WRKDIR}/npm-cache; \
 		${CP} ${FILESDIR}/package.json \
 			${FILESDIR}/package-lock.json ${WRKDIR}/npm-cache; \
@@ -168,7 +169,7 @@ pre-fetch:
 			-e 's:\([gu]id\)=[0-9]*:\1=0:g' \
 			-e 's:flags=.*:flags=none:' \
 			-e 's:^\.:./npm_modules:' > npm_modules.mtree; \
-		${TAR} cJf ${_DISTDIR}/electron-npm-modules-${ELECTRON_VER}${EXTRACT_SUFX} \
+		${TAR} cJf ${DISTDIR}/${DIST_SUBDIR}/electron-npm-modules-${ELECTRON_VER}${EXTRACT_SUFX} \
 			@npm_modules.mtree; \
 		${RM} -r ${WRKDIR}/npm-cache; \
 	fi

--- a/devel/electron5/Makefile
+++ b/devel/electron5/Makefile
@@ -163,7 +163,8 @@ TEST_ALL_TARGET+=	third_party/electron_node:headers
 NPM_TIMESTAMP=	1558776082
 
 pre-fetch:
-	if [ ! -f ${_DISTDIR}/electron-npm-modules-${ELECTRON_VER}${EXTRACT_SUFX} ]; \
+	@${MKDIR} ${DISTDIR}/${DIST_SUBDIR}
+	if [ ! -f ${DISTDIR}/${DIST_SUBDIR}/electron-npm-modules-${ELECTRON_VER}${EXTRACT_SUFX} ]; \
 		then ${MKDIR} ${WRKDIR}/npm-cache; \
 		${CP} ${FILESDIR}/package.json \
 			${FILESDIR}/package-lock.json ${WRKDIR}/npm-cache; \
@@ -175,7 +176,7 @@ pre-fetch:
 			-e 's:\([gu]id\)=[0-9]*:\1=0:g' \
 			-e 's:flags=.*:flags=none:' \
 			-e 's:^\.:./npm_modules:' > npm_modules.mtree; \
-		${TAR} cJf ${_DISTDIR}/electron-npm-modules-${ELECTRON_VER}${EXTRACT_SUFX} \
+		${TAR} cJf ${DISTDIR}/${DIST_SUBDIR}/electron-npm-modules-${ELECTRON_VER}${EXTRACT_SUFX} \
 			@npm_modules.mtree; \
 		${RM} -r ${WRKDIR}/npm-cache; \
 	fi


### PR DESCRIPTION
The destination directory is not automatically generated. A simple MKDIR will fix it.

Moreover, I removed the usage of _DISTDIR in favor of DISTDIR/DIST_SUBDIR
The main reason is that _DISTDIR is an internal variable, is not part of the officially exposed variables, hence there is no guarantee that this variable will be always there or that the name won't change.

If you agree, with this committed, tonight I'll add electron4 to the official ports repo.