### PR TITLE
Add WRKDIR when manually build electron

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,11 +36,12 @@ portsnap fetch
 portsnap extract
 ```
 
-Clone this repository with git command and build/install electron:
+Clone this repository with git command and build/install electron (an external working directory is currently needed, defined with the WRKDIR enviroment variable):
 
 ``` shell
 git clone https://github.com/tagattie/FreeBSD-Electron
 cd FreeBSD-Electron
+export WKRDIR=~/wrkdir
 make install clean
 ```
 

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Clone this repository with git command and build/install electron (an external w
 
 ``` shell
 git clone https://github.com/tagattie/FreeBSD-Electron
-cd FreeBSD-Electron
+cd FreeBSD-Electron/devel/electron4
 export WKRDIR=~/wrkdir
 make install clean
 ```


### PR DESCRIPTION
Adding this vital piece of information in the README :)
that's will close #9 