### PR TITLE
Move electron version to an external file, 

### DIFF
--- a/devel/electron4/Makefile
+++ b/devel/electron4/Makefile
@@ -64,7 +64,6 @@ GH_TUPLE=	electron:node:8bc5d171a0873c0ba49f9433798bc8b67399788c:node
 		# yaml:pyyaml:3.12:pyyaml \
 		# kennethreitz:requests:e4d59bedfd3c7f4f254f4f5d036587bcd8152458:requests
 
-ELECTRON_VER=	4.2.12
 # Official chromium version containing "gn" which is known to work
 CHROMIUM_OFFICIAL_VER=	76.0.3809.132
 # See ${WRKSRC}/electron/DEPS for CHROMIUM_VER
@@ -158,6 +157,7 @@ NPM_TIMESTAMP=	1573298347
 PLIST_SUB=	ELECTRON_VER=${ELECTRON_VER} \
 		PKGNAMESUFFIX=${PKGNAMESUFFIX}
 
+.include "Makefile.version"
 .include "Makefile.tests"
 .include <bsd.port.pre.mk>
 

--- a/devel/electron4/Makefile.version
+++ b/devel/electron4/Makefile.version
@@ -1,0 +1,3 @@
+# $FreeBSD$
+
+ELECTRON_VER=	4.2.12


### PR DESCRIPTION
The new `Makefile.version` contains the version of electron and it can be imported by other ports (atom, for instance), avoid inconsistencies between ports