### PR TITLE
Add dummy implementation for SetListeningForShutdown on FreeBSD

### DIFF
--- a/devel/electron16/files/patch-electron_shell_browser_api_electron__api__power__monitor.cc
+++ b/devel/electron16/files/patch-electron_shell_browser_api_electron__api__power__monitor.cc
@@ -1,0 +1,23 @@
+--- electron/shell/browser/api/electron_api_power_monitor.cc.orig	2022-02-20 09:51:58 UTC
++++ electron/shell/browser/api/electron_api_power_monitor.cc
+@@ -79,6 +79,11 @@ void PowerMonitor::OnResume() {
+   Emit("resume");
+ }
+ 
++#if defined(OS_BSD)
++void PowerMonitor::SetListeningForShutdown(bool is_listening) {
++}
++#endif
++
+ #if defined(OS_LINUX)
+ void PowerMonitor::SetListeningForShutdown(bool is_listening) {
+   if (is_listening) {
+@@ -105,7 +110,7 @@ gin::ObjectTemplateBuilder PowerMonitor::GetObjectTemp
+   auto builder =
+       gin_helper::EventEmitterMixin<PowerMonitor>::GetObjectTemplateBuilder(
+           isolate);
+-#if defined(OS_LINUX)
++#if defined(OS_LINUX) || defined(OS_BSD)
+   builder.SetMethod("setListeningForShutdown",
+                     &PowerMonitor::SetListeningForShutdown);
+ #endif

--- a/devel/electron16/files/patch-electron_shell_browser_api_electron__api__power__monitor.h
+++ b/devel/electron16/files/patch-electron_shell_browser_api_electron__api__power__monitor.h
@@ -1,0 +1,11 @@
+--- electron/shell/browser/api/electron_api_power_monitor.h.orig	2022-02-20 09:52:23 UTC
++++ electron/shell/browser/api/electron_api_power_monitor.h
+@@ -37,7 +37,7 @@ class PowerMonitor : public gin::Wrappable<PowerMonito
+   explicit PowerMonitor(v8::Isolate* isolate);
+   ~PowerMonitor() override;
+ 
+-#if defined(OS_LINUX)
++#if defined(OS_LINUX) || defined(OS_BSD)
+   void SetListeningForShutdown(bool);
+ #endif
+ 


### PR DESCRIPTION
It's needed for Signal-Desktop. The dummy impl seems enough for signal-desktop.