### PR TITLE
devel/electron35: Fix build with rust 1.89.0

### DIFF
--- a/devel/electron35/files/patch-rust-1.89.0
+++ b/devel/electron35/files/patch-rust-1.89.0
@@ -1,0 +1,14 @@
+--- build/rust/allocator/lib.rs.orig	2025-06-18 14:17:42.000000000 +0200
++++ build/rust/allocator/lib.rs	2025-08-24 10:57:12.002293000 +0200
+@@ -89,9 +89,8 @@ mod both_allocators {
+     /// As part of rustc's contract for using `#[global_allocator]` without
+     /// rustc-generated shims we must define this symbol, since we are opting in
+     /// to unstable functionality. See https://github.com/rust-lang/rust/issues/123015
+-    #[no_mangle]
+-    #[linkage = "weak"]
+-    static __rust_no_alloc_shim_is_unstable: u8 = 0;
++    #[rustc_std_internal_symbol]
++    fn __rust_no_alloc_shim_is_unstable_v2() {}
+ 
+     // Mangle the symbol name as rustc expects.
+     #[rustc_std_internal_symbol]


### PR DESCRIPTION
All the electron ports are broken with rust 1.89.0, the error is:
```
ld.lld: error: undefined symbol: __rustc::__rust_no_alloc_shim_is_unstable_v2
>>> referenced by std.6706efb4cc52c99f-cgu.07
>>>               std-0d798e248fa64df7.std.6706efb4cc52c99f-cgu.07.rcgu.o:(core::cell::once::OnceCell$LT$T$GT$::try_init::ha81039204a991fb8 (.llvm.9364531416287518510)) in archive prebuilt_rustc_sysroot/lib/rustlib/x86_64-unknown-freebsd/lib/libstd.rlib
...
```
Upstream patch are
https://chromium.googlesource.com/chromium/src/+/8393b61ba876c8e1614275c97767f9b06b889f48%5E%21/#F0
https://chromium.googlesource.com/chromium/src/+/6aae0e2353c857d98980ff677bf304288d7c58de%5E%21/#F0

I'm not sure how you want to name the file patch-rust-1.89.0